### PR TITLE
feat(server): capture other constructor arguments and forward to base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Options:
  - `maxSendBuffer`: Size of the send buffer in bytes. This governs how much the server can queue to an unacknowledging recipient (for example, during slow connections) before giving up. Messages that exceed the send buffer are dropped. (default: `20000`)
  - `rootObject`: Serialize messages as JSON objects instead of JSON arrays. Useful when handling clients that don't support top-level arrays. (default: `false`)
  - `verbosity`: Show more/less log messages (default `1`). Use `0` to silence.
- - `wssOpts`: Pass all other arguments to the base `WebSocketServer` constructor.
+ - Any other option allowed in [`ws.WebSocketServer`](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback)
 
 #### Event: `'connect'`
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Send message to server.
 
 Listens and waits for clients. Can only be used in back-end environments, not in-browser.
 
-#### `new Server(options? = { host?, port?, maxSendBuffer?, rootObject?, verbosity? })`
+#### `new Server(options? = { host?, port?, maxSendBuffer?, rootObject?, verbosity?, ...wssOpts })`
 
 Create a new server.
 
@@ -289,6 +289,7 @@ Options:
  - `maxSendBuffer`: Size of the send buffer in bytes. This governs how much the server can queue to an unacknowledging recipient (for example, during slow connections) before giving up. Messages that exceed the send buffer are dropped. (default: `20000`)
  - `rootObject`: Serialize messages as JSON objects instead of JSON arrays. Useful when handling clients that don't support top-level arrays. (default: `false`)
  - `verbosity`: Show more/less log messages (default `1`). Use `0` to silence.
+ - `wssOpts`: Pass all other arguments to the base `WebSocketServer` constructor.
 
 #### Event: `'connect'`
 

--- a/server.js
+++ b/server.js
@@ -20,10 +20,14 @@ class Server extends EventEmitter {
             perMessageDeflate: false
         })
         this.server.on('connection', this.add.bind(this))
+        this.server.on('listening', () => {
+            const { port: wssPort, family, address } = this.server.address()
+            const addrStr = family === 'IPv6' ? `[${address}]` : address
+            this.log.info(`Serving websocket server at ws://${addrStr}:${wssPort}. Awaiting clients...`)
+        })
         // Allow clients to subscribe to specific events
         this.on('subscribe', this.subscribe.bind(this))
         this.on('unsubscribe', this.unsubscribe.bind(this))
-        this.log.info(`Serving websocket server at ws://${this.server.options.host}:${this.server.options.port}. Awaiting clients...`)
     }
     add(connection) {
         this.clients.push(new ServerClient(this, connection, this.idTracker++, this.clientOptions))

--- a/server.js
+++ b/server.js
@@ -14,8 +14,8 @@ class Server extends EventEmitter {
         this.server = new WebSocketServer({
             ...wssOpts,
             host,
-            // ignore port if pre-created HTTP/S server to use is specified,
-            // otherwise WebSocketServer will initialize only from port
+            // ignore port if pre-created HTTP/S server to use is specified;
+            // WebSocketServer cannot initialize from a port *and* server context
             port: wssOpts.server ? null : port,
             perMessageDeflate: false
         })

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,3 +1,4 @@
+const http = require('http')
 const MockClient = require('ws')
 const { Server } = require('../server')
 
@@ -37,6 +38,12 @@ describe('Server Creation', () => {
         server = new Server()
         await new Promise(res => server.server.on('listening', res))
         expect(info).toHaveBeenCalledWith('Serving websocket server at ws://127.0.0.1:8090. Awaiting clients...')
+    })
+    it('ignores port when existing http server specified', () => {
+        const httpServer = http.createServer()
+        server = new Server({ port: 54321, server: httpServer })
+        expect(server.server._server).toBe(httpServer)
+        expect(server.server.options.port).toBe(null)
     })
 })
 describe('Client Handling', () => {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -51,6 +51,7 @@ describe('Server Creation', () => {
         server = new Server({ server: httpServer })
         await new Promise(res => httpServer.listen({ port: 54322 }, res))
         expect(info).toHaveBeenCalledWith('Serving websocket server at ws://[::]:54322. Awaiting clients...')
+        return new Promise(res => httpServer.close(res))
     })
 })
 describe('Client Handling', () => {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -45,6 +45,13 @@ describe('Server Creation', () => {
         expect(server.server._server).toBe(httpServer)
         expect(server.server.options.port).toBe(null)
     })
+    it('prints square brackets around ipv6 addresses when listening', async() => {
+        const info = jest.spyOn(console, 'info')
+        const httpServer = http.createServer()
+        server = new Server({ server: httpServer })
+        await new Promise(res => httpServer.listen({ port: 54322 }, res))
+        expect(info).toHaveBeenCalledWith('Serving websocket server at ws://[::]:54322. Awaiting clients...')
+    })
 })
 describe('Client Handling', () => {
     let server


### PR DESCRIPTION
Allows uses to instantiate the base WebSocketServer from an existing `http` server. This is motivated by the desire to host a `ws-plus`  server and an `express` server from the same network port.

Example:
```js
const { Server: WSServer } = require('ws-plus')
const express = require('express')
const http = require('http')

// create an express app
const expressApp = express()
expressApp.get('/', (req, res) => res.send('Hello World'))

// create a root http server context
const server = http.createServer()
server.on('request', expressApp)

// create a ws-plus server
const wsClients = new WSServer({ server })

// host http and wss servers from the same network port
server.listen(54321)
```

Or, with `fasatify`:
```js
const fastify = require('fastify')()
fastify.get('/', (req, reply) => reply.send('Hello World'))
const wsClients = new WSServer({ server: fastify.server })
fastify.listen(54321)
```